### PR TITLE
Pfs3: survive stale sectors when formatting on a physical disk

### DIFF
--- a/src/Hst.Amiga/FileSystems/Pfs3/Disk.cs
+++ b/src/Hst.Amiga/FileSystems/Pfs3/Disk.cs
@@ -71,34 +71,44 @@
             var buffer = await RawRead(blocks, blocknr, g);
 
             var type = typeof(T);
-            if (type == typeof(anodeblock))
+            try
             {
-                return AnodeBlockReader.Parse(buffer, g);
-            }
+                if (type == typeof(anodeblock))
+                {
+                    return AnodeBlockReader.Parse(buffer, g);
+                }
 
-            if (type == typeof(dirblock))
-            {
-                return DirBlockReader.Parse(buffer, g);
-            }
+                if (type == typeof(dirblock))
+                {
+                    return DirBlockReader.Parse(buffer, g);
+                }
 
-            if (type == typeof(indexblock))
-            {
-                return IndexBlockReader.Parse(buffer, g);
-            }
+                if (type == typeof(indexblock))
+                {
+                    return IndexBlockReader.Parse(buffer, g);
+                }
 
-            if (type == typeof(BitmapBlock))
-            {
-                return BitmapBlockReader.Parse(buffer, (int)g.glob_allocdata.longsperbmb);
-            }
+                if (type == typeof(BitmapBlock))
+                {
+                    return BitmapBlockReader.Parse(buffer, (int)g.glob_allocdata.longsperbmb);
+                }
 
-            if (type == typeof(deldirblock))
-            {
-                return DelDirBlockReader.Parse(buffer, g);
-            }
+                if (type == typeof(deldirblock))
+                {
+                    return DelDirBlockReader.Parse(buffer, g);
+                }
 
-            if (type == typeof(rootblockextension))
+                if (type == typeof(rootblockextension))
+                {
+                    return RootBlockExtensionReader.Parse(buffer);
+                }
+            }
+            catch (IOException)
             {
-                return RootBlockExtensionReader.Parse(buffer);
+                // Block id did not match the expected type (e.g. uninitialised/stale sector on a
+                // physical disk). Callers already treat a null return as "no valid block here" and
+                // handle it gracefully, so surface it as null instead of propagating the exception.
+                return null;
             }
 
             return default;

--- a/src/Hst.Amiga/FileSystems/Pfs3/Update.cs
+++ b/src/Hst.Amiga/FileSystems/Pfs3/Update.cs
@@ -664,7 +664,17 @@
             bool first;
             canode anode = new canode();
 
-            await anodes.GetAnode(anode, blk.dirblock.anodenr, g);
+            try
+            {
+                await anodes.GetAnode(anode, blk.dirblock.anodenr, g);
+            }
+            catch (IOException)
+            {
+                // The anode block backing this dir block could not be read (e.g. an
+                // uninitialised sector on a physical disk during format). Treat the
+                // block as first-in-chain so RemoveEmptyDBlocks leaves it alone.
+                return true;
+            }
             first = (anode.blocknr == blk.blocknr);
 
             return first;


### PR DESCRIPTION
Fixes #10.

## Summary

- Catch `IOException` from the block-reader `Parse` dispatch in `Disk.RawRead<T>` and return `null`, matching the contract every caller on the read path already assumes (`GetIndexBlock`, `GetSuperBlock`, `big_GetAnodeBlock` all treat `null` as "no valid block here").
- Catch `IOException` from `GetAnode` in `Update.IsFirstDBlk` and return `true`, so `RemoveEmptyDBlocks` conservatively skips the block (treating it as first-in-chain) rather than tearing down the whole format.

Two lines of behaviour change, both defensive: nothing is silently unlinked or rewritten; at worst an otherwise-empty dir block is retained during format.

## Repro (from #10)

On a physical disk with stale sector data (any used SD card/HDD), `rdb part format` for a PFS3 partition whose sectors sit in previously-untouched territory throws:

```
System.IO.IOException: Invalid index block id '0'
   at Hst.Amiga.FileSystems.Pfs3.IndexBlockReader.Parse(...)
   at Hst.Amiga.FileSystems.Pfs3.Disk.RawRead[T](...)
   at Hst.Amiga.FileSystems.Pfs3.anodes.GetIndexBlock(...)
   at Hst.Amiga.FileSystems.Pfs3.anodes.big_GetAnodeBlock(...)
   at Hst.Amiga.FileSystems.Pfs3.anodes.GetAnode(...)
   at Hst.Amiga.FileSystems.Pfs3.Update.IsFirstDBlk(...)
   at Hst.Amiga.FileSystems.Pfs3.Update.RemoveEmptyDBlocks(...)
   at Hst.Amiga.FileSystems.Pfs3.Update.UpdateDisk(...)
   at Hst.Amiga.FileSystems.Pfs3.Directory.SetDeldir(...)
   at Hst.Amiga.FileSystems.Pfs3.Pfs3Formatter.FormatPartition(...)
```

Trigger: `Pfs3Formatter.FormatPartition` → `Directory.SetDeldir(2, g)` → `UpdateDisk` → `RemoveEmptyDBlocks` walks the just-allocated root dir chain via `IsFirstDBlk` → `GetAnode`, but the anode/index blocks allocated in memory have not yet been flushed to disk. On a zero-filled image the cache paths happen to hide this; on a used physical disk `RawRead` returns real garbage and `IndexBlockReader.Parse` throws.

See #10 for the full reproduction script, disk layout, and analysis.

## Test plan

- [x] Reproduced the failure on a 250 GB SD card previously used for other purposes: 1 GB + 49 GB + 50 GB PFS3 partitions inside a 100 GB MBR type-0x76 container. `SDH0` and `SDH1` format; `SDH2` fails with `Invalid index block id '0'`.
- [x] Same script against a freshly created 100 GB zero-filled VHD with identical cyl numbers formats all three partitions cleanly — confirms the bug is specific to the stale-sector read path.
- [x] With this patch applied (rebuilt as a local `Hst.Amiga` nupkg and referenced from hst-imager's console app), the same repro script on the same SD card now runs end-to-end: boot block, MBR, FAT32, RDB, three PFS3 formats, all complete in a few seconds. `info` reports a valid RDB with three PFS3 partitions.
- [ ] No existing tests touch this cleanup path, so nothing new is asserted automatically; happy to add one against a deliberately-dirtied in-memory stream if that would be useful.

## Environment

- OS: Windows 11 Pro 22H2 x64
- .NET SDK 8.0.303
- hst-amiga: this branch rebased on current `main` (3fc1aae)
- hst-imager: 1.5.564 and 1.6.589 both reproduce the original failure; both are fixed when rebuilt against this branch